### PR TITLE
Fixed a blocking bug, added errors handling and resumable fetching.

### DIFF
--- a/younger_logics_ir/modules/label.py
+++ b/younger_logics_ir/modules/label.py
@@ -264,7 +264,7 @@ class Implementation(object):
         return hash(self.origin)
 
     def __str__(self):
-        return f'Implementation - <Origin/Like/Download/#Performances>: <{self.origin}/{self.like}/{self.download}/{len(self.count_performances())}>'
+        return f'Implementation - <Origin/Like/Download/#Performances>: <{self.origin}/{self.like}/{self.download}/{self.count_performances(None, None)}>'
 
     def __eq__(self, other: 'Implementation') -> bool:
         return self.origin == other.origin

--- a/younger_logics_ir/modules/label.py
+++ b/younger_logics_ir/modules/label.py
@@ -396,10 +396,8 @@ class Implementation(object):
         return self._performances.get(benchmark, dict()).get(evaluation, None)
 
     def insert_performance(self, benchmark: Benchmark, evaluation: Evaluation, performance: Any) -> None:
-        evaluation2performance = self._performances.get(benchmark, dict())
-        if evaluation in evaluation2performance:
-            pass
-        else:
+        evaluation2performance = self._performances.setdefault(benchmark, dict())
+        if evaluation not in evaluation2performance:
             evaluation2performance[evaluation] = performance
 
     def update_performance(self, benchmark: Benchmark, evaluation: Evaluation, performance: Any) -> None:

--- a/younger_logics_ir/scripts/hubs/huggingface/annos.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/annos.py
@@ -282,9 +282,10 @@ def get_heuristic_annotations(model_id: str, model_card_data: ModelCardData) -> 
             if dataset_name in task_name:
                 dataset_name, task_name = task_name, dataset_name
 
-            dataset_split = detect_dataset_split(hf_dataset_split)
-            if dataset_split == '':
-                dataset_split = detect_dataset_split(clean_string(detailed_dataset_name))
+            dataset_split = (
+                detect_dataset_split(hf_dataset_split)
+                or detect_dataset_split(clean_string(detailed_dataset_name))
+            )
 
             if isinstance(hf_metric_value, list):
                 logger.warning(f'Skip. Useless Metric Value. Model ID {model_id} {eval_result.metric_value}')
@@ -305,17 +306,18 @@ def get_heuristic_annotations(model_id: str, model_card_data: ModelCardData) -> 
                 candidate_hf_metrics = [([hf_metric_type, hf_metric_name], str(hf_metric_value))]
 
             for mnames, mvalue in candidate_hf_metrics:
-                if split == '':
-                    split = detect_dataset_split(clean_string(get_detailed_string(mnames)))
+                metric_dataset_split = (
+                    dataset_split
+                    or detect_dataset_split(clean_string(get_detailed_string(mnames)))
+                    or 'test'
+                )
 
                 parsed_mname = parse_metric(mnames)
                 # parsed_mname = mname if parsed_mname == '' else parsed_mname
                 norm_mvalue = normalize_metric_value(parsed_mname, mvalue)
                 metric_info = (parsed_mname, norm_mvalue)
 
-                if split == '':
-                    split = 'test'
-                dataset_info = (dataset_name, dataset_split)
+                dataset_info = (dataset_name, metric_dataset_split)
 
                 annotations['eval_results'].append(
                     dict(

--- a/younger_logics_ir/scripts/hubs/huggingface/convert.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/convert.py
@@ -57,27 +57,55 @@ def safe_optimum_export(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cach
     os.dup2(devnull, 2)
     os.close(devnull)
 
-    try:
-        from optimum.exporters.onnx import main_export
+    saved_fds = {}
 
-        main_export(model_id, cvt_cache_dirpath, opset=onnx_opset_version, device=device, cache_dir=ofc_cache_dirpath, monolith=True, do_validation=False, trust_remote_code=True, no_post_process=True)
-        this_status = 'success'
-        this_error = ''
-    except MemoryError as exception:
-        this_status = 'oversize'
-        this_error = str(exception)
-    except utils.RepositoryNotFoundError as exception:
-        this_status = 'access_deny'
-        this_error = str(exception)
+    try:
+        saved_fds = {1: os.dup(1), 2: os.dup(2)}
+        devnull = os.open(os.devnull, os.O_WRONLY)
+
+        try:
+            os.dup2(devnull, 1)
+            os.dup2(devnull, 2)
+        finally:
+            os.close(devnull)
+
+        try:
+            from optimum.exporters.onnx import main_export
+    
+            main_export(model_id, cvt_cache_dirpath, opset=onnx_opset_version, device=device, cache_dir=ofc_cache_dirpath, monolith=True, do_validation=False, trust_remote_code=True, no_post_process=True)
+            this_status = 'success'
+            this_error = ''
+        except MemoryError as exception:
+            this_status = 'oversize'
+            this_error = str(exception)
+        except utils.RepositoryNotFoundError as exception:
+            this_status = 'access_deny'
+            this_error = str(exception)
+        except Exception as exception:
+            error_text = f"{type(exception).__name__}: {exception}"
+
+            if (
+                type(exception).__name__ == "OutOfMemoryError"
+                or "CUDA out of memory" in err_text
+                or "out of memory" in error_text.lower()
+            ):
+                this_status = "oversize"
+            else:
+                this_status = "convert_error"
+
+            this_error = error_text
     except Exception as exception:
-        this_status = 'convert_error'
-        this_error = f'{type(exception).__name__}: {exception}'
+        this_status = "covert_worker_error"
+        this_error = f"{type(exception).__name__}: {exception}"
+
     finally:
         for fd, saved in saved_fds.items():
-            os.dup2(saved, fd)
-            os.close(saved)
+            try:
+                os.dup2(saved, fd)
+            finally:
+                os.close(saved)
 
-    results_queue.put((this_status, this_error))
+        results_queue.put((this_status, this_error))
 
 
 def convert_optimum(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_dirpath: pathlib.Path, device: Literal['cpu', 'cuda'] = 'cpu') -> tuple[dict[int, tuple[Literal['success', 'oversize', 'access_deny', 'convert_error', 'system_kill'], dict[str, Literal['success', 'logicx_error']]]], list[Instance], list[str]]:

--- a/younger_logics_ir/scripts/hubs/huggingface/convert.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/convert.py
@@ -15,7 +15,6 @@
 
 
 import os
-import re
 import onnx
 import tqdm
 import pathlib
@@ -37,50 +36,8 @@ from younger_logics_ir.commons.constants import YLIROriginHub
 
 from younger_logics_ir.scripts.commons.utils import get_onnx_opset_versions, get_onnx_model_opset_version
 
-from .utils import get_huggingface_hub_model_readme, get_huggingface_hub_model_siblings, clean_huggingface_hub_model_cache, infer_supported_frameworks
+from .utils import get_huggingface_hub_model_readme, get_huggingface_hub_model_siblings, clean_huggingface_hub_model_cache, infer_supported_frameworks, is_permanent_error, get_minimum_opset_from_error
 
-
-def _is_permanent_error(error_message: str) -> bool:
-    """Return True if the error is permanent -- no opset version change can fix it.
-
-    Matches by exception type name (everything before ': '). Exception types that
-    indicate model-loading / config / file-structure issues are permanent because
-    they happen before ONNX export uses the opset version.
-    """
-    _PERMANENT_TYPES = frozenset({
-        'FileNotFoundError',
-        'OSError',
-        'ValueError',
-        'ImportError',
-        'TypeError',
-    })
-    colon_pos = error_message.find(': ')
-    if colon_pos == -1:
-        return False
-    return error_message[:colon_pos] in _PERMANENT_TYPES
-
-
-def _get_minimum_opset_from_error(error_message: str) -> int | None:
-    """Extract the minimum opset version required by an UnsupportedOperatorError.
-
-    Returns None if the error message does not specify a target version.
-    """
-    # e.g. "Support for this operator was added in version 14"
-    match = re.search(
-        r'Support for this operator was added in version (\d+)',
-        error_message,
-    )
-    if match:
-        return int(match.group(1))
-    # e.g. "Please try opset version 11"
-    match = re.search(
-        r'please try opset version (\d+)',
-        error_message,
-        re.IGNORECASE,
-    )
-    if match:
-        return int(match.group(1))
-    return None
 
 
 def clean_cache(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_dirpath: pathlib.Path):
@@ -100,9 +57,9 @@ def safe_optimum_export(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cach
     os.dup2(devnull, 2)
     os.close(devnull)
 
-    from optimum.exporters.onnx import main_export
-
     try:
+        from optimum.exporters.onnx import main_export
+
         main_export(model_id, cvt_cache_dirpath, opset=onnx_opset_version, device=device, cache_dir=ofc_cache_dirpath, monolith=True, do_validation=False, trust_remote_code=True, no_post_process=True)
         this_status = 'success'
         this_error = ''
@@ -157,13 +114,13 @@ def convert_optimum(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_di
 
         if this_status == 'convert_error':
             # Permanent error -> skip remaining opsets entirely
-            if _is_permanent_error(this_error):
+            if is_permanent_error(this_error):
                 logger.warning(f'[opset {onnx_opset_version}] {this_status}: {this_error}')
                 status[onnx_opset_version] = (this_status, this_status_details)
                 break
 
             # Unsupported operator with known minimum version -> jump there
-            target_opset = _get_minimum_opset_from_error(this_error)
+            target_opset = get_minimum_opset_from_error(this_error)
             if target_opset is not None and target_opset > onnx_opset_version:
                 logger.warning(f'[opset {onnx_opset_version}] {this_status}: {this_error}')
                 status[onnx_opset_version] = (this_status, this_status_details)

--- a/younger_logics_ir/scripts/hubs/huggingface/convert.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/convert.py
@@ -462,7 +462,7 @@ def main(
 
     # READMES
     readmes_dirpath = save_dirpath.joinpath(f'READMES')
-    create_dir(instances_dirpath)
+    create_dir(readmes_dirpath)
 
     # Official
     ofc_cache_dirpath = cache_dirpath.joinpath(f'Cache-HFOfc')

--- a/younger_logics_ir/scripts/hubs/huggingface/convert.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/convert.py
@@ -15,6 +15,7 @@
 
 
 import os
+import re
 import onnx
 import tqdm
 import pathlib
@@ -39,25 +40,87 @@ from younger_logics_ir.scripts.commons.utils import get_onnx_opset_versions, get
 from .utils import get_huggingface_hub_model_readme, get_huggingface_hub_model_siblings, clean_huggingface_hub_model_cache, infer_supported_frameworks
 
 
+def _is_permanent_error(error_message: str) -> bool:
+    """Return True if the error is permanent -- no opset version change can fix it.
+
+    Matches by exception type name (everything before ': '). Exception types that
+    indicate model-loading / config / file-structure issues are permanent because
+    they happen before ONNX export uses the opset version.
+    """
+    _PERMANENT_TYPES = frozenset({
+        'FileNotFoundError',
+        'OSError',
+        'ValueError',
+        'ImportError',
+        'TypeError',
+    })
+    colon_pos = error_message.find(': ')
+    if colon_pos == -1:
+        return False
+    return error_message[:colon_pos] in _PERMANENT_TYPES
+
+
+def _get_minimum_opset_from_error(error_message: str) -> int | None:
+    """Extract the minimum opset version required by an UnsupportedOperatorError.
+
+    Returns None if the error message does not specify a target version.
+    """
+    # e.g. "Support for this operator was added in version 14"
+    match = re.search(
+        r'Support for this operator was added in version (\d+)',
+        error_message,
+    )
+    if match:
+        return int(match.group(1))
+    # e.g. "Please try opset version 11"
+    match = re.search(
+        r'please try opset version (\d+)',
+        error_message,
+        re.IGNORECASE,
+    )
+    if match:
+        return int(match.group(1))
+    return None
+
+
 def clean_cache(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_dirpath: pathlib.Path):
     delete_dir(cvt_cache_dirpath, only_clean=True)
     clean_huggingface_hub_model_cache(model_id, ofc_cache_dirpath)
 
 
 def safe_optimum_export(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_dirpath: pathlib.Path, onnx_opset_version: int, results_queue: multiprocessing.Queue, device: str):
+    import os
+
+    # Redirect stdout and stderr to /dev/null BEFORE importing optimum/torch,
+    # otherwise torch registration warnings leak to the parent terminal.
+    # All communication back to the parent process goes through the results_queue.
+    saved_fds = {1: os.dup(1), 2: os.dup(2)}
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    os.dup2(devnull, 1)
+    os.dup2(devnull, 2)
+    os.close(devnull)
+
     from optimum.exporters.onnx import main_export
 
     try:
         main_export(model_id, cvt_cache_dirpath, opset=onnx_opset_version, device=device, cache_dir=ofc_cache_dirpath, monolith=True, do_validation=False, trust_remote_code=True, no_post_process=True)
         this_status = 'success'
+        this_error = ''
     except MemoryError as exception:
         this_status = 'oversize'
+        this_error = str(exception)
     except utils.RepositoryNotFoundError as exception:
         this_status = 'access_deny'
+        this_error = str(exception)
     except Exception as exception:
         this_status = 'convert_error'
+        this_error = f'{type(exception).__name__}: {exception}'
+    finally:
+        for fd, saved in saved_fds.items():
+            os.dup2(saved, fd)
+            os.close(saved)
 
-    results_queue.put(this_status)
+    results_queue.put((this_status, this_error))
 
 
 def convert_optimum(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_dirpath: pathlib.Path, device: Literal['cpu', 'cuda'] = 'cpu') -> tuple[dict[int, tuple[Literal['success', 'oversize', 'access_deny', 'convert_error', 'system_kill'], dict[str, Literal['success', 'logicx_error']]]], list[Instance], list[str]]:
@@ -66,10 +129,10 @@ def convert_optimum(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_di
     instances: list[Instance] = list()
     artifacts: list[str] = list()
 
-    for onnx_opset_version in get_onnx_opset_versions():
-        # The highest opset version supported by torch.onnx.export is 20
-        if onnx_opset_version > 20:
-            continue
+    opset_versions = [v for v in get_onnx_opset_versions() if v <= 20]
+    opset_index = 0
+    while opset_index < len(opset_versions):
+        onnx_opset_version = opset_versions[opset_index]
         results_queue = multiprocessing.Queue()
         subprocess = multiprocessing.Process(target=safe_optimum_export, args=(model_id, cvt_cache_dirpath, ofc_cache_dirpath, onnx_opset_version, results_queue, device))
         subprocess.start()
@@ -78,8 +141,9 @@ def convert_optimum(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_di
         this_status_details: dict[str, Literal['success', 'logicx_error']] = dict()
         if results_queue.empty():
             this_status = 'system_kill'
+            this_error = 'subprocess exited without putting result (likely OOM)'
         else:
-            this_status = results_queue.get()
+            this_status, this_error = results_queue.get()
             if this_status == 'success':
                 for filepath in cvt_cache_dirpath.rglob('*.onnx'):
                     try:
@@ -90,7 +154,36 @@ def convert_optimum(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cache_di
                         this_status_details[str(filepath)] = 'success'
                     except Exception as exception:
                         this_status_details[str(filepath)] = 'logicx_error'
+
+        if this_status == 'convert_error':
+            # Permanent error -> skip remaining opsets entirely
+            if _is_permanent_error(this_error):
+                logger.warning(f'[opset {onnx_opset_version}] {this_status}: {this_error}')
+                status[onnx_opset_version] = (this_status, this_status_details)
+                break
+
+            # Unsupported operator with known minimum version -> jump there
+            target_opset = _get_minimum_opset_from_error(this_error)
+            if target_opset is not None and target_opset > onnx_opset_version:
+                logger.warning(f'[opset {onnx_opset_version}] {this_status}: {this_error}')
+                status[onnx_opset_version] = (this_status, this_status_details)
+                # Find the opset >= target
+                for i in range(opset_index + 1, len(opset_versions)):
+                    if opset_versions[i] >= target_opset:
+                        opset_index = i
+                        break
+                else:
+                    # target_opset beyond our range -> exit
+                    break
+                continue
+
+        # Log and record status
+        if this_status == 'success':
+            logger.info(f'[opset {onnx_opset_version}] {this_status}: {len(this_status_details)} artifacts created')
+        elif this_error:
+            logger.warning(f'[opset {onnx_opset_version}] {this_status}: {this_error}')
         status[onnx_opset_version] = (this_status, this_status_details)
+        opset_index += 1
 
     clean_cache(model_id, cvt_cache_dirpath, ofc_cache_dirpath)
     return status, instances, artifacts
@@ -314,7 +407,8 @@ def get_model_infos_and_convert_method(model_infos_filepath: pathlib.Path, frame
     model_infos: list[dict[str, Any]] = list()
     for model_info in load_json(model_infos_filepath):
         model_frameworks = get_model_frameworks(infer_supported_frameworks(model_info))
-        if framework in model_frameworks and model_size_limit[0] <= model_info['usedStorage'] and model_info['usedStorage'] <= model_size_limit[1]:
+        used_storage = model_info.get('usedStorage', 0)
+        if framework in model_frameworks and model_size_limit[0] <= used_storage and used_storage <= model_size_limit[1]:
             model_infos.append(model_info)
 
     convert_method = supported_convert_methods[framework]
@@ -448,7 +542,7 @@ def main(
             status, instances, artifacts = convert_method(model_id, cvt_cache_dirpath, ofc_cache_dirpath, device)
 
             model_owner, model_name = model_id.split('/')
-            for index, instance, artifact in enumerate(zip(instances, artifacts), start=1):
+            for index, (instance, artifact) in enumerate(zip(instances, artifacts), start=1):
                 instance.insert_label(
                     Implementation(
                         origin=Origin(YLIROriginHub.HUGGINGFACE, model_owner, model_name, artifact),

--- a/younger_logics_ir/scripts/hubs/huggingface/convert.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/convert.py
@@ -51,11 +51,12 @@ def safe_optimum_export(model_id: str, cvt_cache_dirpath: pathlib.Path, ofc_cach
     # Redirect stdout and stderr to /dev/null BEFORE importing optimum/torch,
     # otherwise torch registration warnings leak to the parent terminal.
     # All communication back to the parent process goes through the results_queue.
-    saved_fds = {1: os.dup(1), 2: os.dup(2)}
-    devnull = os.open(os.devnull, os.O_WRONLY)
-    os.dup2(devnull, 1)
-    os.dup2(devnull, 2)
-    os.close(devnull)
+    
+    # saved_fds = {1: os.dup(1), 2: os.dup(2)}
+    # devnull = os.open(os.devnull, os.O_WRONLY)
+    # os.dup2(devnull, 1)
+    # os.dup2(devnull, 2)
+    # os.close(devnull)
 
     saved_fds = {}
 

--- a/younger_logics_ir/scripts/hubs/huggingface/utils.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/utils.py
@@ -91,6 +91,49 @@ def _extract_rate_limit_reset_time(headers: dict) -> float | None:
     return None
 
 
+def is_permanent_error(error_message: str) -> bool:
+    """Return True if the error is permanent -- no opset version change can fix it.
+
+    Matches by exception type name (everything before ': '). Exception types that
+    indicate model-loading / config / file-structure issues are permanent because
+    they happen before ONNX export uses the opset version.
+    """
+    _PERMANENT_TYPES = frozenset({
+        'FileNotFoundError',
+        'OSError',
+        'ValueError',
+        'ImportError',
+        'TypeError',
+    })
+    colon_pos = error_message.find(': ')
+    if colon_pos == -1:
+        return False
+    return error_message[:colon_pos] in _PERMANENT_TYPES
+
+
+def get_minimum_opset_from_error(error_message: str) -> int | None:
+    """Extract the minimum opset version required by an UnsupportedOperatorError.
+
+    Returns None if the error message does not specify a target version.
+    """
+    # e.g. "Support for this operator was added in version 14"
+    match = re.search(
+        r'Support for this operator was added in version (\d+)',
+        error_message,
+    )
+    if match:
+        return int(match.group(1))
+    # e.g. "Please try opset version 11"
+    match = re.search(
+        r'please try opset version (\d+)',
+        error_message,
+        re.IGNORECASE,
+    )
+    if match:
+        return int(match.group(1))
+    return None
+
+
 def _http_request_with_retry(
     session: requests.Session,
     method: str,
@@ -248,23 +291,23 @@ def _is_chunk_completed(filepath: pathlib.Path) -> bool:
 
 def _find_resume_chunk_id(save_dirpath: pathlib.Path, num_of_chunks: int) -> int | None:
     """
-    Scan output files to find the first chunk that has not been completed with storage data.
+    Find the first chunk whose output file is missing or incomplete.
 
-    Returns the CachedChunks current_index to resume from, or None if all chunks are complete.
+    Scans output files sequentially from file number 1 upward.
+    Output files follow 1-based naming: file _{N}.json holds data
+    from CachedChunks chunk N-1 (0-based).
+
+    Returns the 0-based CachedChunks index of the first incomplete chunk,
+    or None if all chunks have complete output files.
     """
-    completed_max = 0  # highest chunk_id (file number) confirmed complete
-    for filepath in save_dirpath.glob('huggingface_hub_model_infos_*.json'):
-        if _is_chunk_completed(filepath):
-            m = re.match(r'huggingface_hub_model_infos_(\d+)\.json', filepath.name)
-            if m:
-                chunk_id = int(m.group(1))
-                if chunk_id > completed_max:
-                    completed_max = chunk_id
-    if completed_max >= num_of_chunks:
-        return None  # All complete
-    # chunk_id (file number) = CachedChunks._current_index after __next__ increment
-    # To re-process the first incomplete chunk, set _current_index to the last completed
-    return completed_max
+    for chunk_index in range(num_of_chunks):
+        file_number = chunk_index + 1
+        filepath = save_dirpath.joinpath(
+            f'huggingface_hub_model_infos_{file_number}.json'
+        )
+        if not (filepath.is_file() and _is_chunk_completed(filepath)):
+            return chunk_index
+    return None
 
 
 def get_huggingface_hub_model_infos(save_dirpath: pathlib.Path, token: str | None = None, number_per_file: int | None = None, worker_number: int | None = None, include_storage: bool = False):

--- a/younger_logics_ir/scripts/hubs/huggingface/utils.py
+++ b/younger_logics_ir/scripts/hubs/huggingface/utils.py
@@ -26,7 +26,7 @@ from typing import Any, Literal, Generator
 from huggingface_hub import utils, HfFileSystem, get_hf_file_metadata, hf_hub_url, scan_cache_dir
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 
-from younger.commons.io import save_json, delete_dir, get_human_readable_size_representation
+from younger.commons.io import load_json, save_json, save_pickle, load_pickle, delete_dir, get_human_readable_size_representation
 from younger.commons.cache import CachedChunks
 from younger.commons.string import extract_possible_digits_from_readme_string, extract_possible_tables_from_readme_string, split_front_matter_from_readme_string, README_DATE_Pattern, README_DATETIME_Pattern, README_TABLE_Pattern
 
@@ -91,10 +91,81 @@ def _extract_rate_limit_reset_time(headers: dict) -> float | None:
     return None
 
 
+def _http_request_with_retry(
+    session: requests.Session,
+    method: str,
+    url: str,
+    max_retries: int = 3,
+    **kwargs,
+) -> requests.Response | None:
+    """
+    HTTP request with timeout and retry on transient errors.
+
+    Retries on: Timeout, ConnectionError (up to max_retries times).
+    On HTTP 429: parses RateLimit header, waits, then retries once.
+    All other errors return None immediately.
+
+    :param session: requests Session to use
+    :param method: HTTP method (GET, POST, etc.)
+    :param url: Request URL
+    :param max_retries: Maximum number of retries for Timeout/ConnectionError (default 3)
+    :param kwargs: Passed through to session.request()
+    :return: Response object or None on failure
+    """
+    kwargs.setdefault('timeout', 30)
+    last_exception = None
+    for attempt in range(max_retries + 1):
+        try:
+            _apply_rate_limit()
+            response = session.request(method, url, **kwargs)
+            utils.hf_raise_for_status(response)
+            return response
+        except requests.exceptions.Timeout as e:
+            last_exception = e
+            logger.warning(f"HTTP timeout for '{url}' (attempt {attempt+1}/{max_retries+1}): {e}")
+        except requests.exceptions.ConnectionError as e:
+            last_exception = e
+            logger.warning(f"HTTP connection error for '{url}' (attempt {attempt+1}/{max_retries+1}): {e}")
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code
+            if status == 429:
+                reset_time = _extract_rate_limit_reset_time(e.response.headers)
+                if reset_time is not None and reset_time > 0:
+                    logger.warning(f"HTTP 429 for '{url}', waiting {reset_time:.1f}s as per RateLimit header...")
+                    time.sleep(reset_time)
+                    # Single retry after waiting
+                    try:
+                        response = session.request(method, url, **kwargs)
+                        utils.hf_raise_for_status(response)
+                        return response
+                    except Exception as retry_e:
+                        logger.error(f"HTTP 429 retry failed for '{url}': {retry_e}")
+                        return None
+                else:
+                    logger.warning(f"HTTP 429 for '{url}' but no valid RateLimit header. Aborting.")
+                    time.sleep(300) # usually a time reset takes 5 min. just in case we hit the worst situation.
+                    return None
+            else:
+                logger.error(f"HTTP {status} for '{url}': {e}")
+                return None
+        except utils.HfHubHTTPError as e:
+            logger.error(f"HF Hub error for '{url}': {e.request_id} - {e.server_message}")
+            return None
+        if attempt < max_retries:
+            wait = 2 ** attempt
+            logger.info(f"Retrying '{url}' in {wait:.1f}s...")
+            time.sleep(wait)
+    logger.error(f"All {max_retries+1} attempts failed for '{url}': {last_exception}")
+    return None
+
+
 def get_one_data_from_huggingface_hub_api(path: str, params: dict | None = None, token: str | None = None) -> Any:
     """
-    Fetch single data from Hugging Face API with rate limiting.
-    On 429, parses RateLimit header and retries once after waiting.
+    Fetch single data from Hugging Face API with rate limiting and timeout.
+
+    On transient errors (timeout, connection error), retries up to 3 times.
+    On HTTP 429, parses RateLimit header, waits, then retries once.
+    On permanent errors (404, 401, etc.), returns None immediately.
 
     :param path: API endpoint
     :param params: Query parameters
@@ -108,43 +179,19 @@ def get_one_data_from_huggingface_hub_api(path: str, params: dict | None = None,
     session = requests.Session()
     headers = utils.build_hf_headers(token=token)
 
-    # First attempt
-    _apply_rate_limit()
-    response = session.get(path, params=params, headers=headers)
-    try:
-        utils.hf_raise_for_status(response)
-        return response.json()
-    except requests.exceptions.HTTPError as e:
-        status = response.status_code
-        if status == 429:
-            # Parse RateLimit header (official HF SDK approach)
-            reset_time = _extract_rate_limit_reset_time(response.headers)
-            if reset_time is not None and reset_time > 0:
-                logger.warning(f"HF API 429 (rate limited). Waiting {reset_time:.1f}s as per RateLimit header...")
-                time.sleep(reset_time)
-                # Single retry after waiting
-                response = session.get(path, params=params, headers=headers)
-                try:
-                    utils.hf_raise_for_status(response)
-                    return response.json()
-                except Exception as retry_e:
-                    logger.error(f"HF API retry after 429 failed: {retry_e}")
-                    return None
-            else:
-                logger.warning(f"HF API 429 but no valid RateLimit header. Aborting.")
-                return None
-        else:
-            logger.error(f"HF API request failed for '{path}' with status {status}: {e}")
-            return None
-    except utils.HfHubHTTPError as e:
-        logger.error(f'Request: {path} {e.request_id} - {e.server_message}')
+    response = _http_request_with_retry(session, 'GET', path, params=params, headers=headers, timeout=30)
+    if response is None:
         return None
+    return response.json()
 
 
 def get_all_data_from_huggingface_hub_api(path: str, params: dict | None = None, token: str | None = None) -> Generator[Any, None, None]:
     """
-    Paginate through Hugging Face API with rate limiting to stay within configured req/5min quota.
-    On 429, parses RateLimit header and retries once after waiting.
+    Paginate through Hugging Face API with rate limiting and timeout.
+
+    On transient errors (timeout, connection error), retries up to 3 times
+    per page request. On HTTP 429, parses RateLimit header, waits, then retries once.
+    On permanent errors, stops pagination.
 
     :param path: API endpoint path
     :param params: Query parameters
@@ -159,82 +206,20 @@ def get_all_data_from_huggingface_hub_api(path: str, params: dict | None = None,
     headers = utils.build_hf_headers(token=token)
 
     # First page
-    _apply_rate_limit()
-    response = session.get(path, params=params, headers=headers)
-    try:
-        utils.hf_raise_for_status(response)
-        yield from response.json()
-        next_page_path = response.links.get("next", {}).get("url")
-    except requests.exceptions.HTTPError as e:
-        status = response.status_code
-        if status == 429:
-            # Parse RateLimit header (official HF SDK approach)
-            reset_time = _extract_rate_limit_reset_time(response.headers)
-            if reset_time is not None and reset_time > 0:
-                logger.warning(f"HF API 429 on first page. Waiting {reset_time:.1f}s as per RateLimit header...")
-                time.sleep(reset_time)
-                # Single retry after waiting
-                response = session.get(path, params=params, headers=headers)
-                try:
-                    utils.hf_raise_for_status(response)
-                    yield from response.json()
-                    next_page_path = response.links.get("next", {}).get("url")
-                except Exception as retry_e:
-                    logger.error(f"HF API retry after 429 failed: {retry_e}")
-                    yield from ()
-                    next_page_path = None
-            else:
-                logger.warning(f"HF API 429 but no valid RateLimit header. Aborting pagination.")
-                yield from ()
-                next_page_path = None
-        else:
-            logger.error(f"HF API request failed for '{path}' with status {status}: {e}")
-            yield from ()
-            next_page_path = None
-    except utils.HfHubHTTPError as e:
-        logger.error(f'Request failed: {e.request_id} - {e.server_message}')
-        yield from ()
-        next_page_path = None
+    response = _http_request_with_retry(session, 'GET', path, params=params, headers=headers, timeout=30)
+    if response is None:
+        return
+    yield from response.json()
+    next_page_path = response.links.get("next", {}).get("url")
 
     # Follow pages
     while next_page_path is not None:
-        _apply_rate_limit()
         logger.debug(f"Pagination: fetching next page")
-        response = session.get(next_page_path, headers=headers)
-        try:
-            utils.hf_raise_for_status(response)
-            yield from response.json()
-            next_page_path = response.links.get("next", {}).get("url")
-        except requests.exceptions.HTTPError as e:
-            status = response.status_code
-            if status == 429:
-                # Parse RateLimit header (official HF SDK approach)
-                reset_time = _extract_rate_limit_reset_time(response.headers)
-                if reset_time is not None and reset_time > 0:
-                    logger.warning(f"HF API 429 on next page. Waiting {reset_time:.1f}s as per RateLimit header...")
-                    time.sleep(reset_time)
-                    # Single retry after waiting
-                    response = session.get(next_page_path, headers=headers)
-                    try:
-                        utils.hf_raise_for_status(response)
-                        yield from response.json()
-                        next_page_path = response.links.get("next", {}).get("url")
-                    except Exception as retry_e:
-                        logger.error(f"HF API retry after 429 failed: {retry_e}")
-                        yield from ()
-                        next_page_path = None
-                else:
-                    logger.warning(f"HF API 429 on next page but no valid RateLimit header. Aborting pagination.")
-                    yield from ()
-                    next_page_path = None
-            else:
-                logger.error(f"HF API pagination request failed with status {status}: {e}")
-                yield from ()
-                next_page_path = None
-        except utils.HfHubHTTPError as e:
-            logger.error(f'Pagination request failed: {e.request_id} - {e.server_message}')
-            yield from ()
-            next_page_path = None
+        response = _http_request_with_retry(session, 'GET', next_page_path, headers=headers, timeout=30)
+        if response is None:
+            return
+        yield from response.json()
+        next_page_path = response.links.get("next", {}).get("url")
 
 
 #############################################################################################################
@@ -248,6 +233,38 @@ def get_huggingface_hub_model_ids(token: str | None = None) -> Generator[dict, N
     # Returns full model objects (id, lastModified, etc.) to preserve metadata without extra API calls
     models = get_all_data_from_huggingface_hub_api(models_path, params=dict(sort='lastModified', direction=-1), token=token)
     return models
+
+
+def _is_chunk_completed(filepath: pathlib.Path) -> bool:
+    """Check if a saved JSON file already contains usedStorage data by peeking at the header."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            # Read first 2KB — the first model's 'usedStorage' key should be within this range
+            head = f.read(2048)
+            return '"usedStorage"' in head
+    except Exception:
+        return False
+
+
+def _find_resume_chunk_id(save_dirpath: pathlib.Path, num_of_chunks: int) -> int | None:
+    """
+    Scan output files to find the first chunk that has not been completed with storage data.
+
+    Returns the CachedChunks current_index to resume from, or None if all chunks are complete.
+    """
+    completed_max = 0  # highest chunk_id (file number) confirmed complete
+    for filepath in save_dirpath.glob('huggingface_hub_model_infos_*.json'):
+        if _is_chunk_completed(filepath):
+            m = re.match(r'huggingface_hub_model_infos_(\d+)\.json', filepath.name)
+            if m:
+                chunk_id = int(m.group(1))
+                if chunk_id > completed_max:
+                    completed_max = chunk_id
+    if completed_max >= num_of_chunks:
+        return None  # All complete
+    # chunk_id (file number) = CachedChunks._current_index after __next__ increment
+    # To re-process the first incomplete chunk, set _current_index to the last completed
+    return completed_max
 
 
 def get_huggingface_hub_model_infos(save_dirpath: pathlib.Path, token: str | None = None, number_per_file: int | None = None, worker_number: int | None = None, include_storage: bool = False):
@@ -269,8 +286,29 @@ def get_huggingface_hub_model_infos(save_dirpath: pathlib.Path, token: str | Non
     else:
         logger.info(f' v Retrieving All Model Infos (Storage excluded) ...')
 
+    # Resume support for storage retrieval: rewind to first incomplete chunk
+    if include_storage:
+        resume_index = _find_resume_chunk_id(save_dirpath, chunks_of_simple_model_infos._num_of_chunks)
+        if resume_index is None:
+            logger.info(f' All chunks already completed with storage data. Nothing to do.')
+            logger.info(f' ^ Retrieved.')
+            return
+        if resume_index < chunks_of_simple_model_infos._current_index:
+            logger.info(f' Resuming from chunk {resume_index} (files _1~_{resume_index} already have storage data)')
+            # Update both the status file (for future restarts) and the in-memory state
+            save_pickle(resume_index, simple_model_infos_cache_dirpath.joinpath(CachedChunks._status_cache_filename_))
+            chunks_of_simple_model_infos._current_index = resume_index
+
     with tqdm.tqdm(initial=chunks_of_simple_model_infos.current_position, total=len(chunks_of_simple_model_infos), desc='Retrieve Model') as progress_bar:
         for chunk_of_simple_model_infos in chunks_of_simple_model_infos:
+            save_filepath = save_dirpath.joinpath(f'huggingface_hub_model_infos_{chunks_of_simple_model_infos.current_chunk_id}.json')
+
+            # Resume: skip chunks whose output files already contain storage data
+            if include_storage and save_filepath.is_file() and _is_chunk_completed(save_filepath):
+                logger.info(f'Skipping already completed chunk → {save_filepath.name}')
+                progress_bar.update(len(chunk_of_simple_model_infos))
+                continue
+
             model_infos_per_file = list()
 
             if include_storage:
@@ -304,7 +342,6 @@ def get_huggingface_hub_model_infos(save_dirpath: pathlib.Path, token: str | Non
                     model_infos_per_file.append(simple_model_info)
                     progress_bar.update(1)
 
-            save_filepath = save_dirpath.joinpath(f'huggingface_hub_model_infos_{chunks_of_simple_model_infos.current_chunk_id}.json')
             save_json(model_infos_per_file, save_filepath, indent=2)
             logger.info(f'Total {len(model_infos_per_file)} Model Info Items Saved In: \'{save_filepath}\'.')
 

--- a/younger_logics_ir/scripts/hubs/onnx/utils.py
+++ b/younger_logics_ir/scripts/hubs/onnx/utils.py
@@ -23,7 +23,7 @@ from younger.commons.string import extract_possible_tables_from_readme_string
 
 
 def get_onnx_hub_model_infos() -> list[dict[str, Any]]:
-    response = requests.get("https://github.com/onnx/models/raw/main/README.md")
+    response = requests.get("https://github.com/onnx/models/raw/main/README.md", timeout=30)
     if response.status_code == 200:
         readme = response.text
     else:
@@ -78,7 +78,7 @@ def get_onnx_hub_model_infos() -> list[dict[str, Any]]:
     tasks = ["Computer_Vision", "Generative_AI", "Graph_Machine_Learning", "Natural_Language_Processing"]
     authors = ["timm", "torch_hub", "torchvision", "transformers", "graph_convolutions"]
 
-    response = requests.get("https://api.github.com/repos/onnx/models/git/trees/main?recursive=1")
+    response = requests.get("https://api.github.com/repos/onnx/models/git/trees/main?recursive=1", timeout=30)
 
     if response.status_code == 200:
         tree_data = response.json()["tree"]


### PR DESCRIPTION
Bugfix:
1. added timeout on each requests, which prervents the blocking of the whole process as the connection might be closed by internet fluctuations.
Features added:
1. the progress of fetching of usedStorage properties is now resumable.
2. opset-version-irrelevant errors skipped directly. Now we don't try every opset version when we meet errors like FileNotFoundError, OSError, ValueError., and so on.
3. For UnsupportedOperatorError that contains supported version, we extract the version number and jump to that version.